### PR TITLE
Ajouter Vitest pour le développement TDD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ yarn-error.log*
 
 # Next.js
 .vercel
+
+# Testing
+coverage
+html
+.vitest
+
+# Vitest
+vitest.config.ts.timestamp-*

--- a/backend/TESTING.md
+++ b/backend/TESTING.md
@@ -1,0 +1,83 @@
+# Guide de test avec Vitest pour Kitten-IA
+
+Ce projet utilise [Vitest](https://vitest.dev/) comme framework de test pour faciliter le développement TDD (Test-Driven Development).
+
+## Commandes disponibles
+
+- `npm test` : Execute tous les tests une fois
+- `npm run test:watch` : Execute les tests en mode watch (réexécute les tests à chaque modification de fichier)
+- `npm run test:cov` : Execute les tests avec génération de rapport de couverture
+- `npm run test:ui` : Lance l'interface utilisateur de Vitest pour une visualisation interactive des tests
+- `npm run test:debug` : Exécute les tests en mode debug
+- `npm run test:e2e` : Exécute les tests end-to-end
+
+## Structure des tests
+
+Les tests sont organisés selon les conventions suivantes :
+
+- Les tests unitaires sont placés à côté des fichiers de code source avec l'extension `.spec.ts`
+- Les tests d'intégration et end-to-end utilisent l'extension `.e2e-spec.ts`
+
+## Utilisation des Builders et Fixtures
+
+Pour faciliter l'écriture des tests, le projet utilise un système de Builders et Fixtures :
+
+### Builders
+
+Les builders permettent de créer facilement des instances d'objets de domaine pour les tests.
+Exemple d'utilisation :
+
+```typescript
+import { kittenBuilder } from './tests/builders/kitten.builder';
+
+// Créer un chaton avec des valeurs par défaut
+const kitten = kittenBuilder().build();
+
+// Ou personnaliser certaines propriétés
+const customKitten = kittenBuilder()
+  .withName('Garfield')
+  .withLevel(5)
+  .build();
+```
+
+### Fixtures
+
+Les fixtures facilitent la mise en place de scénarios de test avec un style BDD (Behavior-Driven Development).
+Exemple d'utilisation :
+
+```typescript
+import { CreateKittenFixture } from './tests/fixtures/kitten.fixture';
+
+describe('Feature: Kitten Creation', () => {
+  let fixture: KittenFixture;
+
+  beforeEach(() => {
+    fixture = CreateKittenFixture();
+  });
+
+  test('creates a kitten with valid details', async () => {
+    // Arrange
+    fixture.givenUsersExists([user]);
+    
+    // Act
+    await fixture.whenKittenIsCreate({
+      name: 'Felix',
+      user: 1,
+    });
+    
+    // Assert
+    await fixture.thenKittenShouldExist({
+      name: 'Felix',
+      user: 1,
+    });
+  });
+});
+```
+
+## Bonnes pratiques
+
+1. **Suivre le principe AAA (Arrange-Act-Assert)**
+2. **Utiliser les builders et fixtures** pour simplifier la mise en place des tests
+3. **Tester les cas d'erreur** en plus des cas de succès
+4. **Isoler les tests** pour qu'ils puissent s'exécuter indépendamment
+5. **Écrire les tests avant le code** pour suivre le TDD

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,11 +13,12 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:cov": "vitest run --coverage",
+    "test:ui": "vitest --ui",
+    "test:debug": "vitest --inspect-brk",
+    "test:e2e": "vitest run --config ./vitest.e2e.config.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",
@@ -47,43 +48,26 @@
     "@nestjs/testing": "^10.3.0",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.21",
-    "@types/jest": "^29.5.11",
     "@types/node": "^20.10.4",
     "@types/passport-jwt": "^3.0.13",
     "@types/passport-local": "^1.0.38",
     "@types/supertest": "^2.0.16",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
+    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/ui": "^1.3.1",
     "eslint": "^8.55.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "jest": "^29.7.0",
     "prettier": "^3.1.0",
     "prisma": "^5.7.0",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",
-    "ts-jest": "^29.1.1",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.3.3"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/backend/src/example.spec.ts
+++ b/backend/src/example.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+
+describe('Example test suite', () => {
+  it('should pass a simple test', () => {
+    expect(1 + 1).toBe(2);
+  });
+  
+  it('should work with async/await', async () => {
+    const result = await Promise.resolve(42);
+    expect(result).toBe(42);
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['**/*.spec.ts'],
+    exclude: ['**/*.e2e-spec.ts', 'node_modules/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@src': resolve(__dirname, './src'),
+      '@test': resolve(__dirname, './test'),
+    },
+  },
+});

--- a/backend/vitest.e2e.config.ts
+++ b/backend/vitest.e2e.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['**/*.e2e-spec.ts'],
+    exclude: ['node_modules/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@src': resolve(__dirname, './src'),
+      '@test': resolve(__dirname, './test'),
+    },
+  },
+});


### PR DESCRIPTION
## Description

Cette pull request ajoute Vitest comme framework de test pour faciliter le développement TDD (Test-Driven Development). Vitest est plus moderne, plus rapide et plus simple à configurer que Jest.

## Changements

- Remplace Jest par Vitest comme framework de test principal
- Ajoute les configurations pour les tests unitaires et e2e
- Met à jour les scripts npm pour utiliser Vitest 
- Ajoute un exemple de test pour valider la configuration
- Crée un document TESTING.md expliquant l'utilisation du framework de test

## Avantages de Vitest

- Meilleure performance que Jest
- API compatible avec Jest (migration facile)
- Support natif de TypeScript (pas besoin de ts-jest)
- UI interactive pour visualiser les tests
- Surveillance des fichiers plus réactive

## Comment tester

1. Installer les dépendances: `npm install`
2. Exécuter les tests: `npm test`
3. Mode watch: `npm run test:watch`
4. UI interactive: `npm run test:ui` 

Cette PR est la première étape vers la refactorisation complète du projet en clean code avec un système de builders/fixtures pour faciliter les tests.