### PR TITLE
Fix: Ajouter des enums pour les tests au lieu d'utiliser ceux de Prisma

### DIFF
--- a/backend/src/battles/battles.service.spec.ts
+++ b/backend/src/battles/battles.service.spec.ts
@@ -4,7 +4,7 @@ import { BattleFixture } from '../test/fixtures/battle-fixture';
 import { userBuilder } from '../test/builders/user.builder';
 import { kittenBuilder } from '../test/builders/kitten.builder';
 import { battleLogBuilder } from '../test/builders/battle-log.builder';
-import { BattleStatus } from '@prisma/client';
+import { BattleStatus } from '../test/constants/enums';
 
 describe('BattlesService', () => {
   let fixture: BattleFixture;

--- a/backend/src/test/builders/ability.builder.ts
+++ b/backend/src/test/builders/ability.builder.ts
@@ -1,5 +1,6 @@
-import { Ability, AbilityType } from '@prisma/client';
+import { Ability } from '@prisma/client';
 import { kittenBuilder } from './kitten.builder';
+import { AbilityType } from '../constants/enums';
 
 interface AbilityOptions {
   id?: string;
@@ -85,7 +86,7 @@ export const abilityBuilder = ({
         id: props.id,
         name: props.name,
         description: props.description,
-        type: props.type,
+        type: props.type as any, // Type casting pour éviter les problèmes de compatibilité
         power: props.power,
         accuracy: props.accuracy,
         cooldown: props.cooldown,

--- a/backend/src/test/builders/battle-log.builder.ts
+++ b/backend/src/test/builders/battle-log.builder.ts
@@ -1,5 +1,6 @@
-import { BattleLog, BattleStatus } from '@prisma/client';
+import { BattleLog } from '@prisma/client';
 import { kittenBuilder } from './kitten.builder';
+import { BattleStatus } from '../constants/enums';
 
 interface BattleLogOptions {
   id?: string;
@@ -100,7 +101,7 @@ export const battleLogBuilder = ({
         challengerId: props.challengerId,
         opponentId: props.opponentId,
         winnerId: props.winnerId,
-        status: props.status,
+        status: props.status as any, // Type casting pour éviter les problèmes de compatibilité
         seed: props.seed,
         replayData: props.replayData,
         totalRounds: props.totalRounds,

--- a/backend/src/test/constants/enums.ts
+++ b/backend/src/test/constants/enums.ts
@@ -1,0 +1,16 @@
+// Énumérations pour les tests qui reflètent celles de Prisma
+export enum BattleStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED'
+}
+
+export enum AbilityType {
+  ATTACK = 'ATTACK',
+  DEFENSE = 'DEFENSE',
+  SPECIAL = 'SPECIAL',
+  HEAL = 'HEAL',
+  BUFF = 'BUFF',
+  DEBUFF = 'DEBUFF'
+}

--- a/backend/src/test/constants/index.ts
+++ b/backend/src/test/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './enums';

--- a/backend/src/test/fixtures/battle-fixture.ts
+++ b/backend/src/test/fixtures/battle-fixture.ts
@@ -1,10 +1,11 @@
-import { BattleLog, BattleStatus, Kitten, User } from '@prisma/client';
+import { BattleLog, Kitten, User } from '@prisma/client';
 import { InMemoryBattleRepository } from '../repositories/in-memory-battle-repository';
 import { InMemoryKittenRepository } from '../repositories/in-memory-kitten-repository';
 import { InMemoryUserRepository } from '../repositories/in-memory-user-repository';
 import { battleLogBuilder } from '../builders/battle-log.builder';
 import { battleMoveBuilder } from '../builders/battle-move.builder';
 import { CreateBattleDto } from '../../battles/dto/create-battle.dto';
+import { BattleStatus } from '../constants/enums';
 
 export class BattleFixture {
   private battleRepository = new InMemoryBattleRepository();


### PR DESCRIPTION
## Description

Cette pull request corrige les erreurs dans les tests liées à l'utilisation des enums `BattleStatus` et `AbilityType` depuis Prisma.

## Problème

Les tests échouaient avec l'erreur suivante :

```
TypeError: Cannot read properties of undefined (reading 'COMPLETED')
```

Le problème était que les tests essayaient d'accéder à l'enum `BattleStatus` de Prisma, mais cette enum n'était pas disponible dans les tests.

## Solution

J'ai implémenté les correctifs suivants :

1. Création d'un dossier `src/test/constants` contenant un fichier `enums.ts` qui définit des enums identiques à ceux de Prisma
2. Mise à jour des fichiers de test et builders pour utiliser ces enums au lieu des enums de Prisma
3. Ajout d'un type casting `as any` dans les builders pour éviter les problèmes de compatibilité de type

## Tests

J'ai vérifié que les tests qui échouaient auparavant fonctionnent maintenant correctement.