### PR TITLE
Fix: Créer les statistiques de kitten si inexistantes lors des batailles

### DIFF
--- a/backend/src/battles/battles.service.ts
+++ b/backend/src/battles/battles.service.ts
@@ -169,19 +169,31 @@ export class BattlesService {
         ? battleState.opponent.id
         : battleState.challenger.id;
 
-    // Mettre à jour les statistiques du vainqueur
-    await this.prisma.kittenStats.update({
+    // Mettre à jour les statistiques du vainqueur (create if not exists)
+    await this.prisma.kittenStats.upsert({
       where: { kittenId: winnerId },
-      data: {
+      update: {
         wins: { increment: 1 },
+      },
+      create: {
+        kittenId: winnerId,
+        wins: 1,
+        losses: 0,
+        draws: 0,
       },
     });
 
-    // Mettre à jour les statistiques du perdant
-    await this.prisma.kittenStats.update({
+    // Mettre à jour les statistiques du perdant (create if not exists)
+    await this.prisma.kittenStats.upsert({
       where: { kittenId: loserId },
-      data: {
+      update: {
         losses: { increment: 1 },
+      },
+      create: {
+        kittenId: loserId,
+        wins: 0,
+        losses: 1,
+        draws: 0,
       },
     });
 


### PR DESCRIPTION
Cette PR modifie la méthode updateKittenStats pour utiliser upsert au lieu de update, ce qui crée automatiquement un enregistrement dans KittenStats si le chaton n'en a pas encore, évitant ainsi les erreurs de clé étrangère lors des combats.