### PR TITLE
Fix: Correct dateProvider injection in CreateAbilityUseCase

### DIFF
--- a/backend/src/abilities/application/usecases/create-ability.usecase.ts
+++ b/backend/src/abilities/application/usecases/create-ability.usecase.ts
@@ -19,13 +19,16 @@ export interface CreateAbilityCommand {
 }
 
 export class CreateAbilityUseCase {
+  private dateProvider: () => Date;
+
   constructor(
     @Inject(ABILITY_REPOSITORY)
     private readonly abilityRepository: AbilityRepository,
     @Inject(KITTEN_REPOSITORY)
-    private readonly kittenRepository: KittenRepository,
-    private readonly dateProvider: () => Date = () => new Date()
-  ) {}
+    private readonly kittenRepository: KittenRepository
+  ) {
+    this.dateProvider = () => new Date();
+  }
 
   setDateProvider(dateProvider: () => Date): void {
     this.dateProvider = dateProvider;


### PR DESCRIPTION
Cette PR corrige le problème d'injection du dateProvider dans le CreateAbilityUseCase.\n\nLe problème est similaire à celui que nous avions rencontré avec le CreateKittenUseCase : NestJS essaie d'injecter un fournisseur pour le troisième paramètre du constructeur (dateProvider) mais n'en trouve pas.\n\nLa solution est de déplacer le dateProvider en tant que propriété de classe initialisée dans le constructeur.