### PR TITLE
Ajoute l'utilisation des méthodes 'then' dans les fixtures de tests

### DIFF
--- a/backend/src/abilities/tests/ability-fixture.ts
+++ b/backend/src/abilities/tests/ability-fixture.ts
@@ -3,6 +3,7 @@ import { Ability } from '@/abilities/domain/ability';
 import { abilityBuilder } from '@/abilities/tests/ability-builder';
 import { InMemoryAbilityRepository } from '@/abilities/tests/in-memory-ability-repository';
 import { InMemoryKittenRepository } from '@/abilities/tests/in-memory-kitten-repository';
+import { expect } from 'vitest';
 
 export interface AbilityFixture {
   getAbilityRepository(): InMemoryAbilityRepository;
@@ -23,12 +24,28 @@ export interface AbilityFixture {
       kittenId: string;
     }>
   ): Ability;
+  
+  // Result and error handling
+  getResult(): any;
+  setResult(result: any): void;
+  getError(): Error | null;
+  setError(error: Error): void;
+  
+  // Then assertions
+  thenResultShouldBeArray(): void;
+  thenResultShouldHaveLength(length: number): void;
+  thenResultShouldContainItemWithProperty(property: string, value: any): void;
+  thenAllResultItemsShouldHaveProperty(property: string, value: any): void;
+  thenErrorShouldBeInstanceOf(errorClass: new (...args: any[]) => Error): void;
+  thenErrorMessageShouldContain(text: string): void;
 }
 
 export function createAbilityFixture(): AbilityFixture {
   const abilityRepository = new InMemoryAbilityRepository();
   const kittenRepository = new InMemoryKittenRepository();
   let currentDate = new Date();
+  let result: any = null;
+  let error: Error | null = null;
 
   return {
     getAbilityRepository(): InMemoryAbilityRepository {
@@ -71,6 +88,48 @@ export function createAbilityFixture(): AbilityFixture {
         .withUpdatedAt(currentDate);
 
       return builder.build();
+    },
+    
+    // Result and error handling
+    getResult(): any {
+      return result;
+    },
+    
+    setResult(newResult: any): void {
+      result = newResult;
+    },
+    
+    getError(): Error | null {
+      return error;
+    },
+    
+    setError(newError: Error): void {
+      error = newError;
+    },
+    
+    // Then assertions
+    thenResultShouldBeArray(): void {
+      expect(Array.isArray(result)).toBe(true);
+    },
+    
+    thenResultShouldHaveLength(length: number): void {
+      expect(result).toHaveLength(length);
+    },
+    
+    thenResultShouldContainItemWithProperty(property: string, value: any): void {
+      expect(result.some((item: any) => item[property] === value)).toBe(true);
+    },
+    
+    thenAllResultItemsShouldHaveProperty(property: string, value: any): void {
+      expect(result.every((item: any) => item[property] === value)).toBe(true);
+    },
+    
+    thenErrorShouldBeInstanceOf(errorClass: new (...args: any[]) => Error): void {
+      expect(error).toBeInstanceOf(errorClass);
+    },
+    
+    thenErrorMessageShouldContain(text: string): void {
+      expect(error?.message).toContain(text);
     }
   };
 }

--- a/backend/src/abilities/tests/usecases/find-all-abilities.usecase.spec.ts
+++ b/backend/src/abilities/tests/usecases/find-all-abilities.usecase.spec.ts
@@ -57,10 +57,16 @@ describe('FindAllAbilitiesUseCase', () => {
     const query = {};
 
     // When
-    const abilities = await findAllAbilitiesUseCase.execute(query);
+    try {
+      const abilities = await findAllAbilitiesUseCase.execute(query);
+      fixture.setResult(abilities);
+    } catch (error) {
+      fixture.setError(error as Error);
+    }
 
     // Then
-    expect(abilities).toHaveLength(3);
+    fixture.thenResultShouldBeArray();
+    fixture.thenResultShouldHaveLength(3);
   });
 
   it('should find abilities for a specific kitten', async () => {
@@ -70,11 +76,17 @@ describe('FindAllAbilitiesUseCase', () => {
     };
 
     // When
-    const abilities = await findAllAbilitiesUseCase.execute(query);
+    try {
+      const abilities = await findAllAbilitiesUseCase.execute(query);
+      fixture.setResult(abilities);
+    } catch (error) {
+      fixture.setError(error as Error);
+    }
 
     // Then
-    expect(abilities).toHaveLength(2);
-    expect(abilities.every(a => a.kittenId === kittenId1)).toBe(true);
+    fixture.thenResultShouldBeArray();
+    fixture.thenResultShouldHaveLength(2);
+    fixture.thenAllResultItemsShouldHaveProperty('kittenId', kittenId1);
   });
 
   it('should return empty array when no abilities found for a kitten', async () => {
@@ -84,9 +96,15 @@ describe('FindAllAbilitiesUseCase', () => {
     };
 
     // When
-    const abilities = await findAllAbilitiesUseCase.execute(query);
+    try {
+      const abilities = await findAllAbilitiesUseCase.execute(query);
+      fixture.setResult(abilities);
+    } catch (error) {
+      fixture.setError(error as Error);
+    }
 
     // Then
-    expect(abilities).toHaveLength(0);
+    fixture.thenResultShouldBeArray();
+    fixture.thenResultShouldHaveLength(0);
   });
 });

--- a/backend/src/kittens/tests/kitten-fixture.ts
+++ b/backend/src/kittens/tests/kitten-fixture.ts
@@ -2,12 +2,13 @@ import { Kitten } from '@/kittens/domain/kitten';
 import { User } from '@/kittens/application/user.repository';
 import { InMemoryKittenRepository } from '@/kittens/tests/in-memory-kitten-repository';
 import { InMemoryUserRepository } from '@/kittens/tests/in-memory-user-repository';
+import { expect } from 'vitest';
 
 export class KittenFixture {
   private readonly kittenRepository = new InMemoryKittenRepository();
   private readonly userRepository = new InMemoryUserRepository();
-  private readonly error: Error | null = null;
-  private readonly result: any = null;
+  private error: Error | null = null;
+  private result: any = null;
   private date: Date = new Date('2024-01-01T00:00:00Z');
 
   givenKittenExists(kittens: Kitten[]): void {
@@ -28,6 +29,14 @@ export class KittenFixture {
 
   getResult(): any {
     return this.result;
+  }
+  
+  setResult(result: any): void {
+    this.result = result;
+  }
+  
+  setError(error: Error): void {
+    this.error = error;
   }
 
   getKittenRepository(): InMemoryKittenRepository {
@@ -50,9 +59,20 @@ export class KittenFixture {
     expect(this.error?.message).toContain(text);
   }
 
-  thenKittenShouldMatchProperties(properties: Partial<Kitten>): void {
+  thenKittenShouldMatchProperties(properties: Partial<Record<string, any>>): void {
     for (const [key, value] of Object.entries(properties)) {
-      expect(this.result[key]).toEqual(value);
+      if (key === 'name') {
+        // La propriété name est une instance de KittenName, donc on doit vérifier sa valeur interne
+        expect(this.result[key].toString()).toEqual(value.value);
+      } else if (key === 'attributes') {
+        // Vérification des attributs
+        for (const [attrKey, attrValue] of Object.entries(value)) {
+          expect(this.result[key][attrKey].value).toEqual(attrValue.value);
+        }
+      } else {
+        // Pour les autres propriétés
+        expect(this.result[key]).toEqual(value);
+      }
     }
   }
 

--- a/backend/src/kittens/tests/usecases/create-kitten.usecase.spec.ts
+++ b/backend/src/kittens/tests/usecases/create-kitten.usecase.spec.ts
@@ -31,26 +31,35 @@ describe('Create Kitten Use Case', () => {
     fixture.givenUserExists([user]);
 
     // When
-    const result = await createKittenUseCase.execute({
-      name: 'Whiskers',
-      strength: 7,
-      agility: 6,
-      constitution: 8,
-      intelligence: 5,
-      userId
-    });
+    try {
+      const result = await createKittenUseCase.execute({
+        name: 'Whiskers',
+        strength: 7,
+        agility: 6,
+        constitution: 8,
+        intelligence: 5,
+        userId
+      });
+      fixture.setResult(result);
+    } catch (error) {
+      fixture.setError(error as Error);
+    }
 
     // Then
-    expect(result).toBeInstanceOf(Kitten);
-    expect(result.name.value).toBe('Whiskers');
-    expect(result.userId).toBe(userId);
-    expect(result.attributes.strength.value).toBe(7);
-    expect(result.attributes.agility.value).toBe(6);
-    expect(result.attributes.constitution.value).toBe(8);
-    expect(result.attributes.intelligence.value).toBe(5);
-    expect(result.level).toBe(1);
-    expect(result.experience).toBe(0);
-    expect(result.skillPoints).toBe(0);
+    fixture.thenResultShouldBeInstanceOf(Kitten);
+    fixture.thenKittenShouldMatchProperties({
+      name: { value: 'Whiskers' },
+      userId: userId,
+      attributes: {
+        strength: { value: 7 },
+        agility: { value: 6 },
+        constitution: { value: 8 },
+        intelligence: { value: 5 }
+      },
+      level: 1,
+      experience: 0,
+      skillPoints: 0
+    });
   });
 
   it('should create a kitten with default attributes if not provided', async () => {
@@ -65,33 +74,44 @@ describe('Create Kitten Use Case', () => {
     fixture.givenUserExists([user]);
 
     // When
-    const result = await createKittenUseCase.execute({
-      name: 'Whiskers',
-      userId
-    });
+    try {
+      const result = await createKittenUseCase.execute({
+        name: 'Whiskers',
+        userId
+      });
+      fixture.setResult(result);
+    } catch (error) {
+      fixture.setError(error as Error);
+    }
 
     // Then
-    expect(result).toBeInstanceOf(Kitten);
-    expect(result.name.value).toBe('Whiskers');
-    expect(result.userId).toBe(userId);
-    expect(result.attributes.strength.value).toBe(5);
-    expect(result.attributes.agility.value).toBe(5);
-    expect(result.attributes.constitution.value).toBe(5);
-    expect(result.attributes.intelligence.value).toBe(5);
+    fixture.thenResultShouldBeInstanceOf(Kitten);
+    fixture.thenKittenShouldMatchProperties({
+      name: { value: 'Whiskers' },
+      userId: userId,
+      attributes: {
+        strength: { value: 5 },
+        agility: { value: 5 },
+        constitution: { value: 5 },
+        intelligence: { value: 5 }
+      }
+    });
   });
 
   it('should throw an error if user does not exist', async () => {
     // When
     try {
-      await createKittenUseCase.execute({
+      const result = await createKittenUseCase.execute({
         name: 'Whiskers',
         userId: 'non-existent-user'
       });
+      fixture.setResult(result);
       // Should not reach here
       expect(true).toBe(false);
     } catch (error) {
+      fixture.setError(error as Error);
       // Then
-      expect(error).toBeInstanceOf(UserNotFoundForKittenCreationError);
+      fixture.thenErrorShouldBeInstanceOf(UserNotFoundForKittenCreationError);
     }
   });
 
@@ -114,15 +134,17 @@ describe('Create Kitten Use Case', () => {
 
     // When
     try {
-      await createKittenUseCase.execute({
+      const result = await createKittenUseCase.execute({
         name: 'Whiskers',
         userId
       });
+      fixture.setResult(result);
       // Should not reach here
       expect(true).toBe(false);
     } catch (error) {
+      fixture.setError(error as Error);
       // Then
-      expect(error).toBeInstanceOf(KittenNameAlreadyExistError);
+      fixture.thenErrorShouldBeInstanceOf(KittenNameAlreadyExistError);
     }
   });
 });


### PR DESCRIPTION
Cette PR corrige l'implémentation des tests dans les modules kittens et abilities en ajoutant l'utilisation des méthodes 'then' disponibles dans les fixtures.

Modifications apportées :
- Modification de la méthode `thenKittenShouldMatchProperties` pour gérer correctement les structures complexes
- Ajout du stockage des résultats avec `setResult` et `setError` dans les tests
- Remplacement des assertions directes par les méthodes 'then' du fixture
- Ajout de méthodes d'assertion dans le fixture des abilities
- Conversion de tous les tests pour utiliser la structure try/catch
- Correction des références à 'repository' remplacées par 'fixture.getKittenRepository()'

Tous les tests passent maintenant avec succès.
